### PR TITLE
Pass in form styling - DO NOT MERGE YET

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -66,7 +66,10 @@ export function createApp (verifyServiceProviderHost: string) {
     saveRequestId,
 
     // A corresponding callback that loads the requestID
-    loadRequestId
+    loadRequestId,
+
+    // A function to add our stylesheet to the autopost saml form provided by passport-verify
+    wrapSamlForm
   ))
 
   app.get('/', (req, res) => res.render('index.njk'))
@@ -155,6 +158,14 @@ export function createApp (verifyServiceProviderHost: string) {
 
   function loadRequestId (request: any) {
     return request.session.requestId
+  }
+
+  function wrapSamlForm (formHtml: string) {
+    return `
+      <link href="../css/app.css" media="screen" rel="stylesheet">
+      <main id='content'>
+        ${formHtml}
+      </main>`
   }
 
   return app

--- a/src/app.ts
+++ b/src/app.ts
@@ -161,11 +161,7 @@ export function createApp (verifyServiceProviderHost: string) {
   }
 
   function wrapSamlForm (formHtml: string) {
-    return `
-      <link href="../css/app.css" media="screen" rel="stylesheet">
-      <main id='content'>
-        ${formHtml}
-      </main>`
+    return nunjucks.render('saml-form-wrapper.njk', { form: formHtml })
   }
 
   return app

--- a/src/assets/css/app.css
+++ b/src/assets/css/app.css
@@ -32,7 +32,7 @@
     }
 }
 
-.button {
+.button, .passport-verify-button {
     background-color: #00823b;
     position: relative;
     display: -moz-inline-stack;
@@ -64,6 +64,10 @@
 }
 .button:visited {
     background-color: #00823b;
+}
+
+form {
+    font-family: "nta", Arial, sans-serif;
 }
 
 table {

--- a/src/views/saml-form-wrapper.njk
+++ b/src/views/saml-form-wrapper.njk
@@ -1,0 +1,11 @@
+{% extends "layouts/govuk_template.html" %}
+
+{% block head %}
+<link href="../css/app.css" media="screen" rel="stylesheet">
+{% endblock %}
+
+{% block content %}
+<main id="content">
+{{form|safe}}
+</main>
+{% endblock %}


### PR DESCRIPTION
This could be the corresponding changes to match the pass in form styling pull request on passport-verify. The template version here makes me slightly worried (particularly the inserting unescaped html into the template to render the form), although it seems likely that it's something rps may want to do (the alternative being to concatenate strings of html in the wrapper function - see the first of these commits).

See [passport-verify pull request](https://github.com/alphagov/passport-verify/pull/17)

It would need an actual version release of passport-verify and then updating the version number here before it can be merged.