### PR TITLE
TT-1215 Displays address history attribute in view-attributes if present

### DIFF
--- a/acceptance-tests/acceptance-tests.ts
+++ b/acceptance-tests/acceptance-tests.ts
@@ -234,6 +234,7 @@ entityIds.forEach(entityId => {
             'DATE_OF_BIRTH_VERIFIED',
             'CURRENT_ADDRESS',
             'CURRENT_ADDRESS_VERIFIED',
+            'ADDRESS_HISTORY',
             'CYCLE_3'
           ]
         }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "govuk_template_jinja": "^0.22.2",
     "nunjucks": "^3.0.1",
     "passport": "^0.3.2",
-    "passport-verify": "0.10.0",
+    "passport-verify": "0.11.0",
     "request": "^2.81.0",
     "request-promise-native": "^1.0.4",
     "zombie": "^5.0.7"

--- a/src/views/view-attributes.njk
+++ b/src/views/view-attributes.njk
@@ -16,7 +16,7 @@
     </thead>
     <tbody>
         {% for name, attribute in user.attributes %}
-            {% if name !== 'address' %}
+            {% if name !== 'address' and name !== 'addressHistory' %}
                 <tr>
                     <td><code>{{name}}</code></td>
                     <td><code>{{attribute.value}}</code></td>
@@ -25,18 +25,17 @@
             {% endif %}
         {% endfor %}
     </tbody>
-
 </table>
 </p>
 {% if user.attributes.address %}
-    <h2 class="heading-medium">Address Attributes - {{ "" if user.attributes.address.verifed else "not " }}verified</h2>
+    <h2 class="heading-medium">Current Address - {{ "" if user.attributes.address.verified else "not " }}verified</h2>
     <p>
         <table>
             <thead> 
                 <th>Attribute Name</th><th>Attribute Value</th>
             </thead>
             {% for addressKey, addressValue in user.attributes.address.value %}
-        
+
                 <tbody>
                     <tr>
                         <td><code>{{addressKey}}</code></td>
@@ -46,6 +45,27 @@
             {% endfor %}
         </table>
     </p>
+{% endif %}
+{% if user.attributes.addressHistory %}
+    <h2 class="heading-medium">Address History</h2>
+    {% for address in user.attributes.addressHistory %}
+        <h2 class="heading-medium">Address {{loop.index}} - {{ "" if address.verified else "not " }}verified</h2>
+        <p>
+            <table>
+                <thead>
+                    <th>Attribute Name</th><th>Attribute Value</th>
+                </thead>
+                {% for addressKey, addressValue in address.value %}
+                    <tbody>
+                        <tr>
+                            <td><code>{{addressKey}}</code></td>
+                        <td><code>{{addressValue}}</code></td>
+                        </tr>
+                    </tbody>
+                {% endfor %}
+            </table>
+        <p>
+    {% endfor %}
 {% endif %}
 </main>
 {% endblock %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1358,9 +1358,9 @@ passport-strategy@1.x.x, passport-strategy@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/passport-strategy/-/passport-strategy-1.0.0.tgz#b5539aa8fc225a3d1ad179476ddf236b440f52e4"
 
-passport-verify@0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/passport-verify/-/passport-verify-0.10.0.tgz#f7a956c46ce7e86a28298fac8f511a46bfeea514"
+passport-verify@0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/passport-verify/-/passport-verify-0.11.0.tgz#857e7acb67657b50c08b325d84b0ce87dc006662"
   dependencies:
     "@types/debug" "0.0.30"
     "@types/escape-html" "^0.0.20"


### PR DESCRIPTION
This adds address history display. 

It does work with the current version of passport-verify (because javascript), but should version bump once the interface updates there are merged/deployed.