### PR TITLE
bau: Fix template lookup on PaaS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ services:
   - docker
 
 before_install:
-  - echo $(docker --version)
-  - echo $(docker-compose --version)
+  - docker --version
+  - docker-compose --version
 
 install:
   - docker-compose up -d --build

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import * as passport from 'passport'
 import { createStrategy, createResponseHandler, TranslatedResponseBody } from 'passport-verify'
 import * as bodyParser from 'body-parser'
 import * as nunjucks from 'nunjucks'
+import * as path from 'path'
 import { DatabaseWrapper } from './databaseWrapper'
 
 export function createApp (verifyServiceProviderHost: string, db: DatabaseWrapper, entityId?: string) {
@@ -12,7 +13,7 @@ export function createApp (verifyServiceProviderHost: string, db: DatabaseWrappe
 
   nunjucks.configure([
     './src/views',
-    './node_modules/govuk_template_jinja/views'
+    path.resolve(require.resolve('govuk_template_jinja'), '..', '..')
   ], {
     autoescape: true,
     express: app


### PR DESCRIPTION
In the latest version of the nodejs buildpack on PaaS the location of
the node_modules directory has changed. Previously the code assumed it
would be in `./node_modules` relative to the current working directory.
It's now in `/deps/0/node_modules` on PaaS.

This causes an issue where the views can't find the govuk_template
template.

Instead of relying on the node script being run from a certain directory
we can use [require.resolve](https://nodejs.org/api/modules.html#modules_require_resolve_request_options)
to look up the path to the module using node's resolution algorithm. We
then have to be a bit hacky and go up a couple of directories to get the
`views` dir that we were configuring nunjucks to use before.

Hopefully this should fix the PaaS apps.