### PR TITLE
Relax package.json "engines" constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "package": "npm run build && npm pack"
   },
   "engines": {
-    "node": "6.14.1"
+    "node": "6.x"
   },
   "author": "Verify",
   "license": "MIT",


### PR DESCRIPTION
Specifying 6.14.1 exactly prevents this from running on the PaaS as
support for 6.14.1 has been removed in a recent buildpack upgrade.

By specifying 6.x instead we'll be able to deploy until the entire node
6 version line drops out of support, at which point we should really
upgrade.