### PR TITLE
YmnUf9Ma: fix deployment to cloud foundry

### DIFF
--- a/dev-manifest-multi-one.yml
+++ b/dev-manifest-multi-one.yml
@@ -2,7 +2,7 @@ memory: 256M
 applications:
   - name: passport-verify-stub-relying-party-multi-one
     buildpack: nodejs_buildpack
-    path: .
+    command: yarn start
     env:
       VERIFY_SERVICE_PROVIDER_HOST: https://verify-service-provider-dev-multi.cloudapps.digital
       ENTITY_ID: http://passport-verify-stub-relying-party-one

--- a/dev-manifest-multi-two.yml
+++ b/dev-manifest-multi-two.yml
@@ -2,7 +2,7 @@ memory: 256M
 applications:
   - name: passport-verify-stub-relying-party-multi-two
     buildpack: nodejs_buildpack
-    path: .
+    command: yarn start
     env:
       VERIFY_SERVICE_PROVIDER_HOST: https://verify-service-provider-dev-multi.cloudapps.digital
       ENTITY_ID: http://passport-verify-stub-relying-party-two

--- a/dev-manifest.yml
+++ b/dev-manifest.yml
@@ -2,6 +2,6 @@ memory: 256M
 applications:
   - name: passport-verify-stub-relying-party-dev
     buildpack: nodejs_buildpack
-    path: .
+    command: yarn start
     env:
       VERIFY_SERVICE_PROVIDER_HOST: https://verify-service-provider-dev.cloudapps.digital


### PR DESCRIPTION
Deplyoments have been failing for a while using these manifests. I think
this might be due to changes in nodejs buildpack that we haven't
accounted for.