### PR TITLE
fSYu2psF: Add eidas E2E tests

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -127,7 +127,7 @@ export function createIdentityApp (verifyServiceProviderHost: string, entityId?:
 
     // Level of Assurance
     // LEVEL_1 or LEVEL2 depending on your service's requirements. Defaults to LEVEL_2.
-    'LEVEL_1'
+    'LEVEL_2'
   ))
 
   async function handleIdentity (responseBody: TranslatedIdentityResponseBody) {


### PR DESCRIPTION
I enabled the eIDAS in hub, but forgot we're using LOA1 :doh: ...
This changes it to LOA2 so eIDAS should work