### PR TITLE
edKsCW79: add a delay to accommodate slow matching

### DIFF
--- a/e2e-tests/e2e-tests.ts
+++ b/e2e-tests/e2e-tests.ts
@@ -40,7 +40,7 @@ describe('A matching journey', () => {
   it('should succeed', async () => {
     await journey(true).then(async function () {
       // matching/user creation happening
-      await delay(2000)
+      await delay(4000)
       const heading = await page.$eval('h1', e => e.innerHTML)
       assert(heading.includes('Success'), 'Actual: ' + heading)
     })


### PR DESCRIPTION
Sometimes the matching process and the meta-refresh on `/response-processing` takes longer than the current delay so the matching tests can be flaky