### PR TITLE
fSYu2psF: Add eIDAS e2e tests

### DIFF
--- a/e2e-tests/e2e-tests.ts
+++ b/e2e-tests/e2e-tests.ts
@@ -28,18 +28,22 @@ function delay (timeout) {
 }
 
 describe('A non-matching journey', () => {
-  it('without eIDAS should succeed', async () => {
-    await eidasEnabledJourney(false).then(async function () {
-      const heading = await page.$eval('h2#heading-non-matching', e => e.innerHTML)
-      assert(heading.includes('Attributes for user with pid:'),'Actual: ' + heading)
-    })
-  }).timeout(10000)
+  describe('when eIDAS is not selected', () => {
+    it('should succeed', async () => {
+      await eidasEnabledJourney(false).then(async function () {
+        const heading = await page.$eval('h2#heading-non-matching', e => e.innerHTML)
+        assert(heading.includes('Attributes for user with pid:'),'Actual: ' + heading)
+      })
+    }).timeout(10000)
+  })
 
-  // TODO: Disabling this test until we have fixed VSP with eIDAS
-  xit('with eIDAS should succeed', async () => {
-    await eidasEnabledJourney(true).then(async function () {
-      const heading = await page.$eval('h2#heading-non-matching', e => e.innerHTML)
-      assert(heading.includes('Attributes for user with pid:'),'Actual: ' + heading)
+  describe('when eIDAS is selected', () => {
+    // TODO: Disabling this test until we have fixed VSP with eIDAS
+    xit('should succeed', async () => {
+      await eidasEnabledJourney(true).then(async function () {
+        const heading = await page.$eval('h2#heading-non-matching', e => e.innerHTML)
+        assert(heading.includes('Attributes for user with pid:'),'Actual: ' + heading)
+      })
     })
   })
 })

--- a/e2e-tests/e2e-tests.ts
+++ b/e2e-tests/e2e-tests.ts
@@ -28,17 +28,25 @@ function delay (timeout) {
 }
 
 describe('A non-matching journey', () => {
-  it('should succeed', async () => {
-    await journey().then(async function () {
+  it('without eIDAS should succeed', async () => {
+    await eidasEnabledJourney(false).then(async function () {
       const heading = await page.$eval('h2#heading-non-matching', e => e.innerHTML)
       assert(heading.includes('Attributes for user with pid:'),'Actual: ' + heading)
     })
-  }).timeout(20000)
+  }).timeout(10000)
+
+  // TODO: Disabling this test until we have fixed VSP with eIDAS
+  xit('with eIDAS should succeed', async () => {
+    await eidasEnabledJourney(true).then(async function () {
+      const heading = await page.$eval('h2#heading-non-matching', e => e.innerHTML)
+      assert(heading.includes('Attributes for user with pid:'),'Actual: ' + heading)
+    })
+  })
 })
 
 describe('A matching journey', () => {
   it('should succeed', async () => {
-    await journey(true).then(async function () {
+    await verifyJourney(true).then(async function () {
       // matching/user creation happening
       await delay(4000)
       const heading = await page.$eval('h1', e => e.innerHTML)
@@ -47,7 +55,7 @@ describe('A matching journey', () => {
   }).timeout(30000)
 })
 
-async function journey (matchUser?: boolean) {
+async function verifyJourney (matchUser?: boolean) {
   await page.goto(host, { waitUntil: 'networkidle2' })
   await page.click('a.button-start')
   await page.waitForSelector('input#start_form_selection_false')
@@ -57,6 +65,30 @@ async function journey (matchUser?: boolean) {
   await page.click("button[value='Stub Idp Demo One']")
   await page.waitForSelector('input#username')
   await page.type('input#username', `stub-idp-demo-one${matchUser ? '-elms' : ''}`)
+  await page.type('input#password', 'bar')
+  await page.click('input#login')
+  await page.waitForSelector('input#agree')
+  await page.click('input#agree')
+  // Due to multiple redirects at this stage we need to delay
+  await delay(1500)
+}
+
+async function eidasEnabledJourney (selectEidas?: boolean) {
+  await page.goto(host, { waitUntil: 'networkidle2' })
+  await page.click('a.button-start')
+  await page.waitForSelector('h1.heading-large')
+  if (selectEidas) {
+    await page.click("a[href='/choose-a-country'")
+  } else {
+    await page.click("a[href='/start'")
+    await page.waitForSelector('input#start_form_selection_false')
+    await page.click('input#start_form_selection_false')
+    await page.click('input#next-button')
+  }
+  await page.waitForSelector("button[value='Stub Idp Demo One']")
+  await page.click("button[value='Stub Idp Demo One']")
+  await page.waitForSelector('input#username')
+  await page.type('input#username', selectEidas ? 'stub-country' : 'stub-idp-demo-one')
   await page.type('input#password', 'bar')
   await page.click('input#login')
   await page.waitForSelector('input#agree')


### PR DESCRIPTION
For the non-matching journey we've enabled eIDAS,
so updating the test accordingly.

Should work after this is merged & released: 
1. https://github.com/alphagov/verify-hub-federation-config/pull/299
2. https://github.com/alphagov/verify-frontend/pull/664

UPDATE: keeping the eIDAS E2E disabled until we [fix](https://trello.com/c/kQ6IX1mr/187-make-vsp-to-accept-eidas-assertions-when-eidas-is-not-enabled) VSP to accept
eIDAS assertions without MSA/eIDAS enabled.