### PR TITLE
BAU: Bump passport-verify dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "govuk_template_jinja": "^0.22.2",
     "nunjucks": "^3.0.1",
     "passport": "^0.3.2",
-    "passport-verify": "2.0.0-rc.1",
+    "passport-verify": "2.0.0-rc.2",
     "pg-promise": "^7.3.2",
     "puppeteer": "^1.12.2",
     "request": "^2.81.0",


### PR DESCRIPTION
After the recent changes we published a new release candidate version of passport-verify.