### PR TITLE
BAU: Fix the acceptance tests

### DIFF
--- a/acceptance-tests/verify-service-provider-with-matching.yml
+++ b/acceptance-tests/verify-service-provider-with-matching.yml
@@ -1,0 +1,54 @@
+# This is an example configuration file to show how to configure
+# the application using a YAML file.
+
+# Dropwizard server connector configuration
+# see: http://www.dropwizard.io/1.3.5/docs/manual/configuration.html#servers
+server:
+  type: simple
+  applicationContextPath: /
+  adminContextPath: /admin
+  connector:
+    type: http
+    port: ${PORT:-50400}
+
+# Logging configuration
+# see: http://www.dropwizard.io/1.3.5/docs/manual/configuration.html#logging
+logging:
+  level: ${LOG_LEVEL:-INFO}
+  appenders:
+    - type: console
+    - type: file
+      currentLogFilename: logs/verify-service-provider.log
+      archivedLogFilenamePattern: logs/verify-service-provider.log.%d.gz
+
+clockSkew: ${CLOCK_SKEW:-PT30s}
+
+# Entity ID (or IDs) that uniquely identifies your service (or services)
+serviceEntityIds: ${SERVICE_ENTITY_IDS:-[]}
+# This should be provided as a JSON array, e.g. '["service-entity-id"]'
+# To use the Verify Service Provider with multiple services, add their entity IDs here, e.g.
+# '["service-one-entity-id", "service-two-entity-id"]'
+
+# Verify Hub Environment. This tells the service provider where the Verify Hub
+# authentication flow begins and where to find the hub metadata the Verify Service
+# Provider consumes to identify the hub.
+# Valid values: COMPLIANCE_TOOL, INTEGRATION, PRODUCTION
+verifyHubConfiguration:
+  environment: ${VERIFY_ENVIRONMENT:-}
+
+# Location of Matching Service Metadata
+# Verify Service Provider consumes the metadata and uses
+# public certificates from it to identify the msa
+msaMetadata:
+  uri: ${MSA_METADATA_URL:-}
+  expectedEntityId: ${MSA_ENTITY_ID:-}
+
+# Private key that is used to sign an AuthnRequest
+samlSigningKey: ${SAML_SIGNING_KEY:-}
+
+# Private key used to decrypt Assertions in the Response
+samlPrimaryEncryptionKey: ${SAML_PRIMARY_ENCRYPTION_KEY:-}
+
+# Secondary private key used to decrypt Assertions in the Response
+# This only needs to be set if during key rotations (for example if your primary encryption certificate is about to expire)
+samlSecondaryEncryptionKey: ${SAML_SECONDARY_ENCRYPTION_KEY:-}

--- a/vsp.Dockerfile
+++ b/vsp.Dockerfile
@@ -5,6 +5,7 @@ ARG GITHUB_TOKEN=""
 EXPOSE 50400
 
 COPY local-vsp-only.env /local-vsp-only.env
+COPY acceptance-tests/verify-service-provider-with-matching.yml /verify-service-provider-with-matching.yml
 
 RUN apt-get install -y unzip
 RUN apt-get install -y jq
@@ -17,4 +18,4 @@ RUN url="$(if [ -z "${GITHUB_TOKEN:-}" ];\
 
 RUN unzip -q verify-service-provider*.zip
 
-CMD /bin/bash -c 'source /local-vsp-only.env && cd verify-service-provider*/ && ./bin/verify-service-provider server ./verify-service-provider.yml'
+CMD /bin/bash -c 'source /local-vsp-only.env && cd verify-service-provider*/ && ./bin/verify-service-provider server ../verify-service-provider-with-matching.yml'


### PR DESCRIPTION
The acceptance tests are written againts the compliance tool. The tests use the
latest released version of VSP which now by default uses non-matching.
However, compliance tool does not support non-matching. This is to add
matching config for VSP when running the acceptance test. In future we should revisit
to see whether we want to still use the compliance tool for this scenario.
This should make the build green.