### PR TITLE
BAU: Update puppeteer Docker image

### DIFF
--- a/ci/puppeteer.Dockerfile
+++ b/ci/puppeteer.Dockerfile
@@ -1,13 +1,15 @@
 FROM node:10-alpine
 
-# Installs latest Chromium (71) package.
+# Installs latest Chromium (73) package.
 RUN apk update && apk upgrade && \
     echo @edge http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
     echo @edge http://nl.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories && \
     apk add --no-cache \
-      chromium@edge \
+      chromium@edge=~73.0.3683.103 \
+      nss@edge \
+      freetype@edge \
       harfbuzz@edge \
-      nss@edge
+      ttf-freefont@edge
 
 # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true


### PR DESCRIPTION
A new Chromium version (used to run e2e tests) has now more dependencies, so
adding them to the container for the puppeteer tests to go green.

As per:
(https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-on-alpine)