### PR TITLE
EID-1731 Extend acceptance tests for unsigned assertions

### DIFF
--- a/e2e-tests/e2e-tests.ts
+++ b/e2e-tests/e2e-tests.ts
@@ -30,7 +30,7 @@ function delay (timeout) {
 describe('A non-matching journey', () => {
   describe('when eIDAS is not selected', () => {
     it('should succeed', async () => {
-      await eidasEnabledJourney(false).then(async function () {
+      await eidasEnabledJourney(false, false).then(async function () {
         const heading = await page.$eval('h2#heading-non-matching', e => e.innerHTML)
         assert(heading.includes('Attributes for user with pid:'),'Actual: ' + heading)
       })
@@ -39,7 +39,16 @@ describe('A non-matching journey', () => {
 
   describe('when eIDAS is selected', () => {
     it('should succeed', async () => {
-      await eidasEnabledJourney(true).then(async function () {
+      await eidasEnabledJourney(true, false).then(async function () {
+        const heading = await page.$eval('h2#heading-non-matching', e => e.innerHTML)
+        assert(heading.includes('Attributes for user with pid:'),'Actual: ' + heading)
+      })
+    }).timeout(10000)
+  })
+
+  describe('when eIDAS assertions are unsigned', () => {
+    it('should succeed', async () => {
+      await eidasEnabledJourney(true, true).then(async function () {
         const heading = await page.$eval('h2#heading-non-matching', e => e.innerHTML)
         assert(heading.includes('Attributes for user with pid:'),'Actual: ' + heading)
       })
@@ -76,7 +85,7 @@ async function verifyJourney (matchUser?: boolean) {
   await delay(1500)
 }
 
-async function eidasEnabledJourney (selectEidas?: boolean) {
+async function eidasEnabledJourney (selectEidas?: boolean, unsignedAssertions?: boolean) {
   await page.goto(host, { waitUntil: 'networkidle2' })
   await page.click('a.button-start')
   await page.waitForSelector('h1.heading-large')
@@ -95,6 +104,9 @@ async function eidasEnabledJourney (selectEidas?: boolean) {
   await page.waitForSelector('input#username')
   await page.type('input#username', selectEidas ? 'stub-country' : 'stub-idp-demo-one')
   await page.type('input#password', 'bar')
+  if (unsignedAssertions) {
+    await page.click('input#assertionOptions_signAssertions')
+  }
   await page.click('input#login')
   await page.waitForSelector('input#agree')
   await page.click('input#agree')


### PR DESCRIPTION
You can run these tests locally against integration:
Install yarn if you don't have it with `$ brew install yarn`, then
```
$ yarn install
$ export E2E_TEST_ENVIRONMENT=https://passport-verify-stub-relying-party-integration.cloudapps.digital
$ yarn run e2e-tests:non-matching
```

### EID-1731 Extend acceptance tests for unsigned assertions
The VSP has been updated to handle unsigned assertions from eIDAS
countries and we should reflect that in these tests, using new
functionality on stub-country.

<img width="277" alt="Screenshot 2019-10-22 at 09 36 59" src="https://user-images.githubusercontent.com/13836290/67269949-918e7f80-f4af-11e9-9771-3c42302b7abb.png">
