### PR TITLE
BAU Downgrade Puppeteer to v1.11.0

### DIFF
--- a/ci/puppeteer.Dockerfile
+++ b/ci/puppeteer.Dockerfile
@@ -1,15 +1,7 @@
 FROM node:10-alpine
 
-# Installs latest Chromium (73) package.
 RUN apk update && apk upgrade && \
-    echo @edge http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
-    echo @edge http://nl.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories && \
-    apk add --no-cache \
-      chromium@edge=~73.0.3683.103 \
-      nss@edge \
-      freetype@edge \
-      harfbuzz@edge \
-      ttf-freefont@edge
+    apk add --no-cache chromium
 
 # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "passport": "^0.3.2",
     "passport-verify": "2.0.1",
     "pg-promise": "^7.3.2",
-    "puppeteer": "^1.12.2",
+    "puppeteer": "1.11.0",
     "request": "^2.81.0",
     "request-promise-native": "^1.0.4",
     "zombie": "^6.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2640,10 +2640,10 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer@^1.12.2:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.17.0.tgz#371957d227a2f450fa74b78e78a2dadb2be7f14f"
-  integrity sha512-3EXZSximCzxuVKpIHtyec8Wm2dWZn1fc5tQi34qWfiUgubEVYHjUvr0GOJojqf3mifI6oyKnCdrGxaOI+lWReA==
+puppeteer@1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.11.0.tgz#63cdbe12b07275cd6e0b94bce41f3fcb20305770"
+  integrity sha512-iG4iMOHixc2EpzqRV+pv7o3GgmU2dNYEMkvKwSaQO/vMZURakwSOn/EYJ6OIRFYOque1qorzIBvrytPIQB3YzQ==
   dependencies:
     debug "^4.1.0"
     extract-zip "^1.6.6"


### PR DESCRIPTION
Currently the `puppeteer-image` task [in the VSP release pipeline is
broken.](https://deployer.tools.signin.service.gov.uk/teams/main/pipelines/verify-service-provider/jobs/puppeteer-image/builds/7)

This is because it tries to build the puppeteer Docker image, which
falls over when trying to install its chromium dependency.

We're currently installing chromium from the edge distribution. The
available versions here change quickly, and [older versions aren't
maintained](https://medium.com/@stschindler/the-problem-with-docker-and-alpines-package-pinning-18346593e891)
which leads to things breaking.

The reason we're installing from edge, is that the version of puppeteer
we're using is [dependant on at least version 73.0.3679.0 of chromium.](https://github.com/GoogleChrome/puppeteer/releases/tag/v1.12.1)

The base image that we're using is itself based on [alpine:3.9](https://github.com/nodejs/docker-node/blob/a9c583095d4cf08bbd68f570a1f9a99780820351/10/alpine/Dockerfile).
Alpine 3.9 only [has version 72.0.3626.121-r0 of chromium available.](https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.9&repo=community)
If you try to install anything newer it falls over. Using the version
would be desirable though as it's more stable (it's been around since
March).

[Version 1.11.0 of puppeteer](https://github.com/GoogleChrome/puppeteer/releases/tag/v1.11.0) only depends on chromium 72.0.3618.0. By dropping to this version we
can stop relying on the edge distribution of alpine which will give us
more stability, as well as making the package install simpler.

I've looked at the release notes for 1.12.1 and we're not using any of
the new features, and running locally all the tests still pass.