### PR TITLE
AUT-14: Update compliance-tool's URL address

### DIFF
--- a/acceptance-tests/acceptance-tests.ts
+++ b/acceptance-tests/acceptance-tests.ts
@@ -23,7 +23,7 @@ let VERIFY_SERVICE_PROVIDER_HOST = process.env['VERIFY_SERVICE_PROVIDER_HOST'] |
 if (!process.env['VERIFY_SERVICE_PROVIDER_HOST']) {
   console.log('Warning: VERIFY_SERVICE_PROVIDER_HOST not set, using localhost:50400 by default. Use the --paas flag to run against the service provider on paas.')
 }
-const COMPLIANCE_TOOL_HOST = 'https://compliance-tool-reference.ida.digital.cabinet-office.gov.uk'
+const COMPLIANCE_TOOL_HOST = 'https://compliance-tool-integration.cloudapps.digital'
 
 let DATABASE_CONNECTION_STRING = process.env['DATABASE_CONNECTION_STRING']
 if (!DATABASE_CONNECTION_STRING) {


### PR DESCRIPTION
Compliance tool is using the new URL address ""https://compliance-tool-integration.cloudapps.digital"" and it no longer needs the old URL address "https://compliance-tool-reference.ida.digital.cabinet-office.gov.uk". This change updates the URL address for compliance tool because VSP has been updated to use the new URL address. This change will fix acceptance tests failures.

Author: @adityapahuja