### PR TITLE
BAU: Fix PostgreSQL database error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
         - ./database-schema.sql:/docker-entrypoint-initdb.d/database-schema.sql
     environment:
     - POSTGRES_DB=stub_rp_test
+    - POSTGRES_HOST_AUTH_METHOD=trust
   vsp:
     env_file:
         - local-vsp-only.env


### PR DESCRIPTION
This change fixes the following error by adding POSTGRES_HOST_AUTH_METHOD=trust to the docker-compose.yml file.

```
Error: Database is uninitialized and superuser password is not specified.
       You must specify POSTGRES_PASSWORD to a non-empty value for the
       superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".
       You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
       connections without a password. This is *not* recommended.
       See PostgreSQL documentation about "trust":
       https://www.postgresql.org/docs/current/auth-trust.html
```

Author: @adityapahuja