### PR TITLE
BAU: Make compliance tool url configurable

### DIFF
--- a/acceptance-tests/acceptance-tests.ts
+++ b/acceptance-tests/acceptance-tests.ts
@@ -23,7 +23,12 @@ let VERIFY_SERVICE_PROVIDER_HOST = process.env['VERIFY_SERVICE_PROVIDER_HOST'] |
 if (!process.env['VERIFY_SERVICE_PROVIDER_HOST']) {
   console.log('Warning: VERIFY_SERVICE_PROVIDER_HOST not set, using localhost:50400 by default. Use the --paas flag to run against the service provider on paas.')
 }
-const COMPLIANCE_TOOL_HOST = 'https://compliance-tool-reference.ida.digital.cabinet-office.gov.uk'
+
+let complianceToolUrl = 'https://compliance-tool-reference.ida.digital.cabinet-office.gov.uk'
+if (process.env['COMPLIANCE_TOOL_URL']) {
+  complianceToolUrl = process.env['COMPLIANCE_TOOL_URL']
+}
+const COMPLIANCE_TOOL_HOST = complianceToolUrl
 
 let DATABASE_CONNECTION_STRING = process.env['DATABASE_CONNECTION_STRING']
 if (!DATABASE_CONNECTION_STRING) {


### PR DESCRIPTION
Compliance tool is using the new URL address ""https://compliance-tool-integration.cloudapps.digital""; and it no longer needs the old URL address "https://compliance-tool-reference.ida.digital.cabinet-office.gov.uk";. New version of Verify Service Provider is using the new URL address.

COMPLIANCE_TOOL_HOST is set to the hardcoded URL address `https://compliance-tool-reference.ida.digital.cabinet-office.gov.uk`. Since Verify Service Provider (VSP) has been changed to use the new compliance tool URL address `https://compliance-tool-integration.cloudapps.digital`, COMPLIANCE_TOOL_HOST needs to be changed. This change adds an environment variable 'COMPLIANCE_TOOL_URL' which will be used to set COMPLIANCE_TOOL_HOST. The default value for COMPLIANCE_TOOL_HOST is still `https://compliance-tool-reference.ida.digital.cabinet-office.gov.uk`.

I ran acceptance tests using the new compliance tool url address. They passed.

Author: @adityapahuja