### PR TITLE
BAU: Fix e2e tests timeout issue

### DIFF
--- a/e2e-tests/e2e-tests.ts
+++ b/e2e-tests/e2e-tests.ts
@@ -88,7 +88,7 @@ async function verifyJourney (matchUser?: boolean) {
 async function eidasEnabledJourney (selectEidas?: boolean, unsignedAssertions?: boolean) {
   await page.goto(host, { waitUntil: 'networkidle2' })
   await page.click('a.button-start')
-  await page.waitForSelector('h1.heading-large')
+  await page.waitForSelector('h1.govuk-heading-l')
   if (selectEidas) {
     await page.click("a[href='/choose-a-country']")
     await page.waitForSelector("button[value='Stub IDP Demo']")


### PR DESCRIPTION
There is a commit made to app/views/prove_identity/prove_identity.html.erb in verify-frontend which replaces `heading-large` with `govuk-heading-l`. (Source: https://github.com/alphagov/verify-frontend/commit/a10ba86528de564602337a8aadbbc2e069f959bd?diff=split). This causes e2e tests to wait indefinitely for non-existent header level 1 labelled with `heading-large`. This change updates e2e tests to look for header level 1 labelled with `govuk-heading-l`. This should fix the timeout issues. 

I ran e2e tests and they passed.

```
  A non-matching journey
    when eIDAS is not selected
      ✓ should succeed (6780ms)
    when eIDAS is selected
      ✓ should succeed (5213ms)
    when eIDAS assertions are unsigned
      ✓ should succeed (4869ms)


  3 passing (17s)

Done in 24.84s.
```

Author: @adityapahuja