### PR TITLE
BAU: specify compliance url

### DIFF
--- a/acceptance-tests/acceptance-tests.ts
+++ b/acceptance-tests/acceptance-tests.ts
@@ -24,11 +24,7 @@ if (!process.env['VERIFY_SERVICE_PROVIDER_HOST']) {
   console.log('Warning: VERIFY_SERVICE_PROVIDER_HOST not set, using localhost:50400 by default. Use the --paas flag to run against the service provider on paas.')
 }
 
-let complianceToolUrl = 'https://compliance-tool-reference.ida.digital.cabinet-office.gov.uk'
-if (process.env['COMPLIANCE_TOOL_URL']) {
-  complianceToolUrl = process.env['COMPLIANCE_TOOL_URL']
-}
-const COMPLIANCE_TOOL_HOST = complianceToolUrl
+const COMPLIANCE_TOOL_HOST = process.env['COMPLIANCE_TOOL_URL'] || 'https://compliance-tool-reference.ida.digital.cabinet-office.gov.uk'
 
 let DATABASE_CONNECTION_STRING = process.env['DATABASE_CONNECTION_STRING']
 if (!DATABASE_CONNECTION_STRING) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     environment:
         - DATABASE_CONNECTION_STRING=postgresql://postgres:@test-db:5432/stub_rp_test
         - VERIFY_SERVICE_PROVIDER_HOST=http://vsp:50400
+        - COMPLIANCE_TOOL_URL=https://compliance-tool-integration.cloudapps.digital
     command: /bin/bash -c "echo 'app container ready' && sleep 600"
   test-db:
     image: postgres


### PR DESCRIPTION
Test was failing because it was defaulting to the old 'https://compliance-tool-reference.ida.digital.cabinet-office.gov.uk/SAML2/SSO' the new one is 'https://compliance-tool-integration.cloudapps.digital/SAML2/SSO' 

Please see: https://github.com/alphagov/passport-verify-stub-relying-party/pull/62