### PR TITLE
BAU Allow the app to run a bash command for pre-commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ghcr.io/alphagov/verify/node:10.23.2-alpine3.11
-
+RUN apk add --no-cache bash
 EXPOSE 3200
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
The [test-passport-verify-stub job](https://cd.gds-reliability.engineering/teams/verify/pipelines/verify-service-provider/jobs/test-passport-verify-stub/builds/4) is failing as we're trying to run `/bin/bash -c yarn run pre-commit` in an alpine-based image, which doesn't have bash 😱.

Add bash to the image. Tested locally.