### PR TITLE
[HUB-841] Use Docker Hub rather than GHCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/alphagov/verify/node:10.23.2-alpine3.11
+FROM node:10.23.2-alpine3.11
 
 EXPOSE 3200
 

--- a/ci/puppeteer.Dockerfile
+++ b/ci/puppeteer.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.23.2-alpine3.11@sha256:ab51a7c2f883929f6b82248595693e3954ecdf862a2d1104219fbe19bd78855d
+FROM node:10.23.2-alpine3.11
 
 RUN apk update && apk upgrade && \
     apk add --no-cache chromium

--- a/ci/puppeteer.Dockerfile
+++ b/ci/puppeteer.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/alphagov/verify/node:10.23.2-alpine3.11
+FROM node:10.23.2-alpine3.11@sha256:ab51a7c2f883929f6b82248595693e3954ecdf862a2d1104219fbe19bd78855d
 
 RUN apk update && apk upgrade && \
     apk add --no-cache chromium

--- a/db.Dockerfile
+++ b/db.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/alphagov/verify/postgres:12.5
+FROM postgres:12.5
 
 ENV POSTGRES_DB=stub_rp_test
 COPY ./database-schema.sql /docker-entrypoint-initdb.d/database-schema.sql

--- a/vsp.Dockerfile
+++ b/vsp.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/alphagov/verify/java:openjdk-11
+FROM openjdk:11-jre-slim
 
 ARG GITHUB_TOKEN=""
 


### PR DESCRIPTION
We've moved back to using Docker Hub rather than GHCR

Signed-off-by: Chris Mills <7100370+chriscoffee@users.noreply.github.com>