### PR TITLE
BAU: Fix passport stub deployment

### DIFF
--- a/ci/dev-manifest-multi-one.yml
+++ b/ci/dev-manifest-multi-one.yml
@@ -1,7 +1,7 @@
 memory: 256M
 applications:
   - name: passport-verify-stub-relying-party-multi-one
-    buildpack: nodejs_buildpack
+    buildpack: https://github.com/cloudfoundry/nodejs-buildpack.git#v1.7.41
     command: yarn start
     env:
       VERIFY_SERVICE_PROVIDER_HOST: https://verify-service-provider-dev-multi.cloudapps.digital

--- a/ci/dev-manifest-multi-two.yml
+++ b/ci/dev-manifest-multi-two.yml
@@ -1,7 +1,7 @@
 memory: 256M
 applications:
   - name: passport-verify-stub-relying-party-multi-two
-    buildpack: nodejs_buildpack
+    buildpack: https://github.com/cloudfoundry/nodejs-buildpack.git#v1.7.41
     command: yarn start
     env:
       VERIFY_SERVICE_PROVIDER_HOST: https://verify-service-provider-dev-multi.cloudapps.digital

--- a/ci/dev-manifest.yml
+++ b/ci/dev-manifest.yml
@@ -1,7 +1,7 @@
 memory: 256M
 applications:
   - name: passport-verify-stub-relying-party-dev
-    buildpack: nodejs_buildpack
+    buildpack: https://github.com/cloudfoundry/nodejs-buildpack.git#v1.7.41
     command: yarn start
     env:
       VERIFY_SERVICE_PROVIDER_HOST: https://verify-service-provider-dev.cloudapps.digital

--- a/ci/integration-manifest.yml
+++ b/ci/integration-manifest.yml
@@ -3,5 +3,5 @@ applications:
     memory: 512M
     services:
       - ((database))
-    buildpack: nodejs_buildpack
+    buildpack: https://github.com/cloudfoundry/nodejs-buildpack.git#v1.7.41
     command: yarn start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,9 @@ services:
     entrypoint: /bin/sh
     command: -c "echo 'app container ready' && sleep 600"
   test-db:
-    image: postgres
+    build:
+      context: .
+      dockerfile: db.Dockerfile
     volumes:
         - ./database-schema.sql:/docker-entrypoint-initdb.d/database-schema.sql
     environment:


### PR DESCRIPTION
  - Use the database Dockerfile to build the test-db service when running passport tests
  - Use older version of the nodejs buildpack that still supports node version 10