### PR TITLE
BAU: Fix Docker Hub rate limiting

### DIFF
--- a/ci/puppeteer.Dockerfile
+++ b/ci/puppeteer.Dockerfile
@@ -1,4 +1,5 @@
-FROM node:10.23.2-alpine3.11
+ARG base_image=node:10.23.2-alpine3.11
+FROM ${base_image}
 
 RUN apk update && apk upgrade && \
     apk add --no-cache chromium


### PR DESCRIPTION
Use the `base_image` ARG which will be overridden by the OCI build task in the pipeline. This means we're preload the base image using creds and use that preloaded image in the pipeline, which avoid anonymous pull from Docker Hub.